### PR TITLE
don't rely on `this` being the global object

### DIFF
--- a/robust-websocket.js
+++ b/robust-websocket.js
@@ -235,4 +235,4 @@
   }
 
   return RobustWebSocket
-}, this)
+}, typeof window != 'undefined' ? window : global)


### PR DESCRIPTION
In SystemJS, `this` is actually not the global object.