### PR TITLE
allow shouldReconnect to opt into handling 1000 events

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ function shouldReconnect(event, ws) {
 
 See documentation for [CloseEvent] and [online event](https://developer.mozilla.org/en-US/docs/Online_and_offline_events), the two types of events that `shouldReconnect` will receive.
 
+Typically, websockets closed with code `1000` indicate that the socket
+closed normally. In these cases, `robust-websocket` won't call
+`shouldReconnect` (and will not attempt to reconnect), unless you set
+`shouldReconnect.handle1000` to `true`.
+
 ### Polyfills needed
 
 You may need these polyfills to support older browsers

--- a/robust-websocket.js
+++ b/robust-websocket.js
@@ -103,7 +103,7 @@
     }
 
     function reconnect(event) {
-      if (event.code === 1000 || explicitlyClosed) {
+      if ((!opts.shouldReconnect.handle1000 && event.code === 1000) || explicitlyClosed) {
         attempts = 0
         return
       }

--- a/test/tests.js
+++ b/test/tests.js
@@ -177,7 +177,7 @@ describe('RobustWebSocket', function() {
       ws.onclose = sinon.spy(function(evt) {
         evt.code.should.equal(1000)
       })
-      return Promise.delay(1000).then(function() {
+      return pollUntilPassing(function() {
         attemptLog.should.deep.equal([0, 0, 0])
         ws.onclose.should.have.been.calledThrice
         shouldReconnect.should.have.been.calledThrice

--- a/test/tests.js
+++ b/test/tests.js
@@ -156,6 +156,35 @@ describe('RobustWebSocket', function() {
     })
 
     it('should not reconnect on normal disconnects (1000)', !isIEOrEdge && shouldNotReconnect(1000))
+
+    it('should call shouldReconnect on normal disconnects if handle1000 is true', !isIEOrEdge && function() {
+      // Issue #14
+      var attemptLog = [],
+      rounds = 0,
+      shouldReconnect = sinon.spy(function(event, ws) {
+        event.type.should.equal('close')
+        event.currentTarget.should.be.instanceof(WebSocket)
+        // ws.attempts is reset on each successful open, so we separately track the number of open-close
+        // cycles using `rounds`
+        attemptLog.push(ws.attempts)
+        return rounds++ < 2 && 100
+      })
+      shouldReconnect.handle1000 = true;
+
+      ws = new RobustWebSocket(serverUrl + '/?exitCode=1000&exitMessage=alldone&delay=250', null, {
+        shouldReconnect: shouldReconnect
+      })
+      ws.onclose = sinon.spy(function(evt) {
+        evt.code.should.equal(1000)
+      })
+      return Promise.delay(1000).then(function() {
+        attemptLog.should.deep.equal([0, 0, 0])
+        ws.onclose.should.have.been.calledThrice
+        shouldReconnect.should.have.been.calledThrice
+        ws.readyState.should.equal(WebSocket.CLOSED)
+      })
+    })
+
     it('should not reconnect 1008 by default (HTTP 400 equvalent)', !isIEOrEdge && shouldNotReconnect(1008))
     it('should not reconnect 1011 by default (HTTP 500 equvalent)', !isIEOrEdge && shouldNotReconnect(1011))
 


### PR DESCRIPTION
`reconnect` now checks for an optional handle1000 attribute on `shouldReconnect`, and, if truthy, lets it decide whether to reconnect or not. Closes #14