### PR TITLE
fix: only call `send` when it is available

### DIFF
--- a/robust-websocket.js
+++ b/robust-websocket.js
@@ -75,7 +75,7 @@
     }
 
     self.send = function() {
-      return realWs.send.apply(realWs, arguments)
+      return realWs.send && realWs.send.apply(realWs, arguments)
     }
 
     self.close = function(code, reason) {


### PR DESCRIPTION
There are some conditions where `realWs` is the stubbed version, and `send` isn't available. Calling `send` will cause an `Error: cannot call apply of undefined`. This changes the facade `send` to guard for this error, causing `send()` to be a noop if `realWs` is the stubbed version.