### PR TITLE
Point to new repo location

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # robust-websocket
 
+# This repository has moved to https://github.com/nathanboktae/robust-websocket
+
 #### A robust, reconnecting WebSocket client for the browser
 
 [![SauceLabs Test Status](https://saucelabs.com/browser-matrix/robustwebsocket.svg)](https://saucelabs.com/u/robustwebsocket)


### PR DESCRIPTION
It would be great if this could be merged and in addition this repository could be "Archived" to prevent new issues/PRs being reported here. You can archive the repo by going to https://github.com/appuri/robust-websocket/settings and clicking "Archive this repository"
 
<img width="772" alt="image" src="https://user-images.githubusercontent.com/118266/46507099-c1300280-c82e-11e8-8005-7bd339a9301c.png">
